### PR TITLE
[CICD-83] Cancel the failed build directly instead of the parent

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -32,8 +32,8 @@ if [ -n "$if_condition" ]; then
 fi
 
 function add_annotation() {
-  local annotation_body="This build was canceled early due to a failure in <a href='https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}#${BUILDKITE_JOB_ID}'>${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}#${BUILDKITE_BUILD_NUMBER}</a>."
-  local build_id="${BUILDKITE_TRIGGERED_FROM_BUILD_ID:-$BUILDKITE_BUILD_ID}"
+  local annotation_body="This build was canceled early due to a failure in <a href='https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}#${BUILDKITE_JOB_ID}'>this</a> job."
+  local build_id="${BUILDKITE_BUILD_ID}"
   local graphql_build_id="$(printf "Build---%s" "$build_id" | base64)"
   local graphql_query="mutation {
     buildAnnotate(input: {buildID: \"$graphql_build_id\", body: \"$annotation_body\", context: \"bail-early-plugin\", style: ERROR}) {
@@ -53,8 +53,8 @@ function add_annotation() {
 
 function cancel_build() {
   local org="$BUILDKITE_ORGANIZATION_SLUG"
-  local pipeline="${BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG:-$BUILDKITE_PIPELINE_SLUG}"
-  local build_number="${BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER:-$BUILDKITE_BUILD_NUMBER}"
+  local pipeline="${BUILDKITE_PIPELINE_SLUG}"
+  local build_number="${BUILDKITE_BUILD_NUMBER}"
 
   curl -s "https://api.buildkite.com/v2/organizations/${org}/pipelines/${pipeline}/builds/$build_number/cancel" \
     -X PUT \


### PR DESCRIPTION
This helps make it easier for users to understand what's going on and track down the failed jobs.