### PR TITLE
Skip SIGTERM caused exits

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -10,6 +10,11 @@ if [ "$BUILDKITE_COMMAND_EXIT_STATUS" = "-1" ]; then
   exit 0
 fi
 
+if [ "$BUILDKITE_COMMAND_EXIT_STATUS" = "143" ]; then
+  echo "skipping SIGTERM exit code 143; exiting"
+  exit 0
+fi
+
 if [ -z "$BUILDKITE_TOKEN" ]; then
   echo "BUILDKITE_TOKEN not provided; exiting"
   exit 0


### PR DESCRIPTION
Canceling a job may result in it exiting with code `143` due to the SIGTERM. If not skipping, cascading cancels by this plugin will overwrite the original annotation and make it hard to track which job caused the build cancellation.